### PR TITLE
Refactoring to use HKStatisticsCollectionQuery instead of HKSampleQuery.

### DIFF
--- a/ios/UseHealthKit.xcodeproj/project.pbxproj
+++ b/ios/UseHealthKit.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		B3E7B58A1CC2AC0600A0062D /* UseHealthKit.m in Sources */ = {isa = PBXBuildFile; fileRef = B3E7B5891CC2AC0600A0062D /* UseHealthKit.m */; };
 		FE201DC4233CD9E8008730D5 /* UseHealthKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE201DC3233CD9E8008730D5 /* UseHealthKit.swift */; };
+		FE5A0B3823705ACE00C0AAD5 /* Query.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE5A0B3723705ACE00C0AAD5 /* Query.swift */; };
 		FEDFC2602344EBDE00973D9D /* QuantityType.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEDFC25F2344EBDE00973D9D /* QuantityType.swift */; };
 /* End PBXBuildFile section */
 
@@ -29,6 +30,7 @@
 		B3E7B5891CC2AC0600A0062D /* UseHealthKit.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = UseHealthKit.m; sourceTree = "<group>"; };
 		FE201DC2233CD9E8008730D5 /* UseHealthKit-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UseHealthKit-Bridging-Header.h"; sourceTree = "<group>"; };
 		FE201DC3233CD9E8008730D5 /* UseHealthKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UseHealthKit.swift; sourceTree = "<group>"; };
+		FE5A0B3723705ACE00C0AAD5 /* Query.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Query.swift; sourceTree = "<group>"; };
 		FEDFC25F2344EBDE00973D9D /* QuantityType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuantityType.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -66,6 +68,7 @@
 				FE201DC3233CD9E8008730D5 /* UseHealthKit.swift */,
 				B3E7B5891CC2AC0600A0062D /* UseHealthKit.m */,
 				FEDFC25F2344EBDE00973D9D /* QuantityType.swift */,
+				FE5A0B3723705ACE00C0AAD5 /* Query.swift */,
 			);
 			path = UseHealthKit;
 			sourceTree = "<group>";
@@ -130,6 +133,7 @@
 			files = (
 				FEDFC2602344EBDE00973D9D /* QuantityType.swift in Sources */,
 				FE201DC4233CD9E8008730D5 /* UseHealthKit.swift in Sources */,
+				FE5A0B3823705ACE00C0AAD5 /* Query.swift in Sources */,
 				B3E7B58A1CC2AC0600A0062D /* UseHealthKit.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ios/UseHealthKit/QuantityType.swift
+++ b/ios/UseHealthKit/QuantityType.swift
@@ -48,8 +48,9 @@ class QuantityType {
         let type = HKQuantityType.quantityType(forIdentifier: .bodyMass)!
         let options: HKStatisticsOptions = [.discreteAverage]
 
-        let query = Query.makeHKStatisticsCollectionQuery(type, options, startDate, endDate)
-        query.initialResultsHandler = completion
+        let query = Query.makeHKStatisticsCollectionQuery(type, options, startDate, endDate) {
+            query, result, error in completion(query, result, error)
+        }
 
         healthStore.execute(query)
     }

--- a/ios/UseHealthKit/QuantityType.swift
+++ b/ios/UseHealthKit/QuantityType.swift
@@ -30,14 +30,8 @@ class QuantityType {
                               _ endDate: Double,
                               _ completion: @escaping (_ results: [HKSample]?, _ error: Error?) -> Void) {
         let type = HKQuantityType.quantityType(forIdentifier: .basalEnergyBurned)!
-        let predicate = HKQuery.predicateForSamples(withStart: Date(timeIntervalSince1970: startDate),
-                                                    end: Date(timeIntervalSince1970: endDate),
-                                                    options: [.strictStartDate, .strictEndDate])
-        let sortDescriptor = NSSortDescriptor(key: HKSampleSortIdentifierEndDate, ascending: true)
-        let query = HKSampleQuery(sampleType: type,
-                                  predicate: predicate,
-                                  limit: HKObjectQueryNoLimit,
-                                  sortDescriptors: [sortDescriptor]) { _, results, error in completion(results, error) }
+
+        let query = Query.makeHKSampleQuery(type, startDate, endDate) { _, results, error in completion(results, error) }
 
         healthStore.execute(query)
     }
@@ -86,14 +80,8 @@ class QuantityType {
                              _ endDate: Double,
                              _ completion: @escaping (_ results: [HKSample]?, _ error: Error?) -> Void) {
         let type = HKQuantityType.quantityType(forIdentifier: .restingHeartRate)!
-        let predicate = HKQuery.predicateForSamples(withStart: Date(timeIntervalSince1970: startDate),
-                                                    end: Date(timeIntervalSince1970: endDate),
-                                                    options: [.strictStartDate, .strictEndDate])
-        let sortDescriptor = NSSortDescriptor(key: HKSampleSortIdentifierEndDate, ascending: true)
-        let query = HKSampleQuery(sampleType: type,
-                                  predicate: predicate,
-                                  limit: HKObjectQueryNoLimit,
-                                  sortDescriptors: [sortDescriptor]) { _, results, error in completion(results, error) }
+
+        let query = Query.makeHKSampleQuery(type, startDate, endDate) { _, results, error in completion(results, error) }
 
         healthStore.execute(query)
     }

--- a/ios/UseHealthKit/QuantityType.swift
+++ b/ios/UseHealthKit/QuantityType.swift
@@ -1,3 +1,4 @@
+import Foundation
 import HealthKit
 
 /// QuantityType
@@ -51,27 +52,9 @@ class QuantityType {
                      _ endDate: Double,
                      _ completion: @escaping (_ query: HKStatisticsCollectionQuery, _ result: HKStatisticsCollection?, _ error: Error?) -> Void) {
         let type = HKQuantityType.quantityType(forIdentifier: .bodyMass)!
-
-        let predicate = HKQuery.predicateForSamples(withStart: Date(timeIntervalSince1970: startDate),
-                                                    end: Date(timeIntervalSince1970: endDate),
-                                                    options: [.strictStartDate, .strictEndDate])
-
         let options: HKStatisticsOptions = [.discreteAverage]
 
-        let from = Date(timeIntervalSince1970: startDate)
-        var anchorDateComponent = Calendar.current.dateComponents([.year, .month, .day], from: from)
-        anchorDateComponent.hour = 0
-        let anchorDate = Calendar.current.date(from: anchorDateComponent)!
-
-        var interval = DateComponents()
-        interval.day = 1
-
-        let query = HKStatisticsCollectionQuery(quantityType: type,
-                                                quantitySamplePredicate: predicate,
-                                                options: options,
-                                                anchorDate: anchorDate,
-                                                intervalComponents: interval)
-
+        let query = Query.makeHKStatisticsCollectionQuery(type, options, startDate, endDate)
         query.initialResultsHandler = completion
 
         healthStore.execute(query)

--- a/ios/UseHealthKit/QuantityType.swift
+++ b/ios/UseHealthKit/QuantityType.swift
@@ -28,10 +28,13 @@ class QuantityType {
     ///   - completion: handler when the query completes.
     func getBasalEnergyBurned(_ startDate: Double,
                               _ endDate: Double,
-                              _ completion: @escaping (_ results: [HKSample]?, _ error: Error?) -> Void) {
+                              _ completion: @escaping (_ query: HKStatisticsCollectionQuery, _ result: HKStatisticsCollection?, _ error: Error?) -> Void) {
         let type = HKQuantityType.quantityType(forIdentifier: .basalEnergyBurned)!
+        let options: HKStatisticsOptions = [.cumulativeSum]
 
-        let query = Query.makeHKSampleQuery(type, startDate, endDate) { _, results, error in completion(results, error) }
+        let query = Query.makeHKStatisticsCollectionQuery(type, options, startDate, endDate) {
+            query, result, error in completion(query, result, error)
+        }
 
         healthStore.execute(query)
     }
@@ -79,10 +82,13 @@ class QuantityType {
     ///   - completion: handler when the query completes.
     func getRestingHeartRate(_ startDate: Double,
                              _ endDate: Double,
-                             _ completion: @escaping (_ results: [HKSample]?, _ error: Error?) -> Void) {
+                             _ completion: @escaping (_ query: HKStatisticsCollectionQuery, _ result: HKStatisticsCollection?, _ error: Error?) -> Void) {
         let type = HKQuantityType.quantityType(forIdentifier: .restingHeartRate)!
+        let options: HKStatisticsOptions = [.discreteAverage]
 
-        let query = Query.makeHKSampleQuery(type, startDate, endDate) { _, results, error in completion(results, error) }
+        let query = Query.makeHKStatisticsCollectionQuery(type, options, startDate, endDate) {
+            query, result, error in completion(query, result, error)
+        }
 
         healthStore.execute(query)
     }

--- a/ios/UseHealthKit/Query.swift
+++ b/ios/UseHealthKit/Query.swift
@@ -42,7 +42,8 @@ class Query {
                                                 _ endDate: Double,
                                                 _ predicate: NSPredicate? = nil,
                                                 _ anchorDate: Date? = nil,
-                                                _ interval: DateComponents? = nil) -> HKStatisticsCollectionQuery {
+                                                _ interval: DateComponents? = nil,
+                                                _ completion: @escaping (_ query: HKStatisticsCollectionQuery, _ result: HKStatisticsCollection?, _ error: Error?) -> Void) -> HKStatisticsCollectionQuery {
         let _predicate = HKQuery.predicateForSamples(withStart: Date(timeIntervalSince1970: startDate),
                                                      end: Date(timeIntervalSince1970: endDate),
                                                      options: [.strictStartDate, .strictEndDate])
@@ -55,10 +56,13 @@ class Query {
         var _interval = DateComponents()
         _interval.day = 1
 
-        return HKStatisticsCollectionQuery(quantityType: type,
-                                           quantitySamplePredicate: (predicate != nil) ? predicate! : _predicate,
-                                           options: options,
-                                           anchorDate: (anchorDate != nil) ? anchorDate! : _anchorDate,
-                                           intervalComponents: (interval != nil) ? interval! : _interval)
+        let query = HKStatisticsCollectionQuery(quantityType: type,
+                                                quantitySamplePredicate: (predicate != nil) ? predicate! : _predicate,
+                                                options: options,
+                                                anchorDate: (anchorDate != nil) ? anchorDate! : _anchorDate,
+                                                intervalComponents: (interval != nil) ? interval! : _interval)
+        query.initialResultsHandler = { query, result, error in completion(query, result, error) }
+
+        return query
     }
 }

--- a/ios/UseHealthKit/Query.swift
+++ b/ios/UseHealthKit/Query.swift
@@ -2,9 +2,33 @@ import Foundation
 import HealthKit
 
 class Query {
-    /// Get sample data of BodyMass.
+    /// Get HKSampleQuery.
+    ///
     /// - Parameters:
-    ///   - type: type to get data
+    ///   - type: type to get data.
+    ///   - startDate: start date to get data.
+    ///   - endDate: end date to get data.
+    ///   - completion: handler when the query completes.
+    static func makeHKSampleQuery(_ type: HKQuantityType,
+                                  _ startDate: Double,
+                                  _ endDate: Double,
+                                  _ completion: @escaping (_ query: HKSampleQuery, _ results: [HKSample]?, _ error: Error?) -> Void) -> HKSampleQuery {
+        let predicate = HKQuery.predicateForSamples(withStart: Date(timeIntervalSince1970: startDate),
+                                                    end: Date(timeIntervalSince1970: endDate),
+                                                    options: [.strictStartDate, .strictEndDate])
+        let limit = HKObjectQueryNoLimit
+        let sortDescriptor = NSSortDescriptor(key: HKSampleSortIdentifierEndDate, ascending: true)
+        let query = HKSampleQuery(sampleType: type,
+                                  predicate: predicate,
+                                  limit: limit,
+                                  sortDescriptors: [sortDescriptor]) { query, results, error in completion(query, results, error) }
+
+        return query
+    }
+
+    /// Get HKStatisticsCollectionQuery.
+    /// - Parameters:
+    ///   - type: type to get data.
     ///   - options: <#options description#>
     ///   - startDate: start date to get data.
     ///   - endDate: end date to get data.

--- a/ios/UseHealthKit/Query.swift
+++ b/ios/UseHealthKit/Query.swift
@@ -1,0 +1,40 @@
+import Foundation
+import HealthKit
+
+class Query {
+    /// Get sample data of BodyMass.
+    /// - Parameters:
+    ///   - type: type to get data
+    ///   - options: <#options description#>
+    ///   - startDate: start date to get data.
+    ///   - endDate: end date to get data.
+    ///   - predicate: <#predicate description#>
+    ///   - anchorDate: <#anchorDate description#>
+    ///   - interval: interval of collection. Default value is 1 day.
+    ///   - completion: handler when the query completes.
+    static func makeHKStatisticsCollectionQuery(_ type: HKQuantityType,
+                                                _ options: HKStatisticsOptions,
+                                                _ startDate: Double,
+                                                _ endDate: Double,
+                                                _ predicate: NSPredicate? = nil,
+                                                _ anchorDate: Date? = nil,
+                                                _ interval: DateComponents? = nil) -> HKStatisticsCollectionQuery {
+        let _predicate = HKQuery.predicateForSamples(withStart: Date(timeIntervalSince1970: startDate),
+                                                     end: Date(timeIntervalSince1970: endDate),
+                                                     options: [.strictStartDate, .strictEndDate])
+
+        let from = Date(timeIntervalSince1970: startDate)
+        var anchorDateComponent = Calendar.current.dateComponents([.year, .month, .day], from: from)
+        anchorDateComponent.hour = 0
+        let _anchorDate = Calendar.current.date(from: anchorDateComponent)!
+
+        var _interval = DateComponents()
+        _interval.day = 1
+
+        return HKStatisticsCollectionQuery(quantityType: type,
+                                           quantitySamplePredicate: (predicate != nil) ? predicate! : _predicate,
+                                           options: options,
+                                           anchorDate: (anchorDate != nil) ? anchorDate! : _anchorDate,
+                                           intervalComponents: (interval != nil) ? interval! : _interval)
+    }
+}


### PR DESCRIPTION
Completed below tasks.

1. Use HKStatisticsCollectionQuery instead of HKSampleQuery to send JS-layer meaningful data.
(ex) [ {1572447600: 115}, {1572534000: 114}, {1572620400: 113}, {1572706800: 112} ]

2. Add Query class for make queries.